### PR TITLE
feat(cli): Add CLI support for running Meshtastic bots 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ bottastic --port /dev/ttyUSB0 bottastic.bottastic:PingPongBot
 bottastic --host 192.168.1.100 bottastic.bottastic:PingPongBot
 
 # Enable echo options
-bottastic --port /dev/ttyUSB0 bottastic.bottastic:PingPongBot --echo_sent=True --echo_recieved=True
+bottastic --port /dev/ttyUSB0 bottastic.bottastic:PingPongBot --echo_sent=True --echo_received=True
 
 # Enable verbose logging
 bottastic --port /dev/ttyUSB0 bottastic.bottastic:PingPongBot -v
@@ -66,5 +66,5 @@ bottastic --port /dev/ttyUSB0 mybot:MyCustomBot
 - `--tcp HOST` - Connect via TCP to a specified hostname/IP
 - `--port PATH` - Connect via serial to a specified port (e.g., /dev/ttyUSB0)
 - `--echo_sent BOOL` - Whether to print sent messages to console
-- `--echo_recieved BOOL` - Whether to print received messages to console
+- `--echo_received BOOL` - Whether to print received messages to console
 - `--verbose`, `-v` - Enable verbose logging

--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# Bottastic
+
+A framework for building bots for Meshtastic networks.
+
+## Installation
+
+```bash
+git clone https://github.com/sharph/bottastic.git
+cd bottastic
+uv sync
+```
+
+## Usage
+
+Bottastic provides a command-line interface to run your bots. You can [connect to a Meshtastic device via serial or TCP](https://meshtastic.org/docs/software/python/cli/usage).
+
+### Basic Usage
+
+```bash
+# Run a bot using automatic serial device detection
+bottastic bottastic.bottastic:PingPongBot
+
+# Run a bot with a specific serial port
+bottastic --port /dev/ttyUSB0 bottastic.bottastic:PingPongBot
+
+# Run a bot using TCP connection
+bottastic --host 192.168.1.100 bottastic.bottastic:PingPongBot
+
+# Enable echo options
+bottastic --port /dev/ttyUSB0 bottastic.bottastic:PingPongBot --echo_sent=True --echo_recieved=True
+
+# Enable verbose logging
+bottastic --port /dev/ttyUSB0 bottastic.bottastic:PingPongBot -v
+```
+
+### Creating Your Own Bot
+
+Create a Python module with a class that inherits from `Bottastic`:
+
+```python
+# mybot.py
+from bottastic.bottastic import Bottastic, MeshtasticNode
+
+class MyCustomBot(Bottastic):
+    async def handle_message(self, from_node: MeshtasticNode, message: str):
+        if message.startswith('hello'):
+            await self.send_message(f"Hello there, {from_node.short_name}!")
+
+    async def handle_direct_message(self, from_node: MeshtasticNode, message: str):
+        await from_node.send_message(f"You sent me: {message}")
+
+    async def on_initialized(self):
+        print(f"Bot initialized with node ID: {self.my_node['id']}")
+        # Send a startup message
+        await self.send_message("MyCustomBot is now online!")
+```
+
+Then run your bot:
+
+```bash
+bottastic --port /dev/ttyUSB0 mybot:MyCustomBot
+```
+
+## Available Options
+
+- `--tcp HOST` - Connect via TCP to a specified hostname/IP
+- `--port PATH` - Connect via serial to a specified port (e.g., /dev/ttyUSB0)
+- `--echo_sent BOOL` - Whether to print sent messages to console
+- `--echo_recieved BOOL` - Whether to print received messages to console
+- `--verbose`, `-v` - Enable verbose logging

--- a/bottastic/bottastic.py
+++ b/bottastic/bottastic.py
@@ -67,7 +67,7 @@ class MeshtasticNode:
             raise NoEncryptionKey()
 
         def _on_deliver(_):
-            if self.bottastic.echo_sent and self.bottastic.echo_recieved:
+            if self.bottastic.echo_sent and self.bottastic.echo_received:
                 print(f"Delivered message to {self.id}: {text}")
 
         await call_async(
@@ -90,11 +90,11 @@ class Bottastic(ABC):
         self,
         interface: meshtastic.mesh_interface.MeshInterface,
         echo_sent: bool = False,
-        echo_recieved: bool = False,
+        echo_received: bool = False,
     ):
         self.interface = interface
         self.echo_sent = echo_sent
-        self.echo_recieved = echo_recieved
+        self.echo_received = echo_received
         self.loop = None
         self.my_node = None
         self.my_user = None
@@ -110,13 +110,13 @@ class Bottastic(ABC):
             raise Exception("Loop not set up")
         asyncio.run_coroutine_threadsafe(self._on_connect(), self.loop)
 
-    def _handle_on_recieve(self, packet):
+    def _handle_on_receive(self, packet):
         if not self.loop or not self.my_node:
             return
         if "decoded" not in packet or "text" not in packet["decoded"]:
             return
         if packet["to"] == meshtastic.BROADCAST_NUM:
-            if self.echo_recieved:
+            if self.echo_received:
                 print(f"Message from {packet['fromId']}: {packet['decoded']['text']}")
             asyncio.run_coroutine_threadsafe(
                 self.handle_message(
@@ -128,7 +128,7 @@ class Bottastic(ABC):
             return
         if packet["to"] != self.my_node["num"]:
             return
-        if self.echo_recieved:
+        if self.echo_received:
             print(
                 f"Direct message from {packet['fromId']}: {packet['decoded']['text']}"
             )
@@ -149,7 +149,7 @@ class Bottastic(ABC):
         want_response=False,
     ):
         def _on_deliver(_):
-            if self.echo_sent and self.echo_recieved:
+            if self.echo_sent and self.echo_received:
                 print(f"Delivered message: {text}")
 
         await call_async(
@@ -193,7 +193,7 @@ def on_receive(packet, interface: meshtastic.mesh_interface.MeshInterface):
     """called when a packet arrives"""
     for registered_bot in _registered_bots:
         if registered_bot.interface is interface:
-            registered_bot._handle_on_recieve(packet)
+            registered_bot._handle_on_receive(packet)
 
 
 def on_connection(

--- a/bottastic/bottastic.py
+++ b/bottastic/bottastic.py
@@ -1,7 +1,6 @@
 import asyncio
 import base64
 import logging
-import sys
 from abc import ABC
 from concurrent.futures import ThreadPoolExecutor
 
@@ -231,8 +230,3 @@ class PingPongBot(Bottastic):
                 await from_node.send_message(f"pong! hello, {from_node.long_name}")
             else:
                 await from_node.send_message("pong!")
-
-
-if __name__ == "__main__":
-    interface = meshtastic.tcp_interface.TCPInterface(hostname=sys.argv[1])
-    PingPongBot(interface, echo_sent=True, echo_recieved=True).run()

--- a/bottastic/cli.py
+++ b/bottastic/cli.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+import argparse
+import importlib
+import logging
+import sys
+from typing import Type, Dict, Any
+
+import meshtastic
+import meshtastic.tcp_interface
+import meshtastic.serial_interface
+
+from bottastic.bottastic import Bottastic
+
+
+def import_bot_class(bot_path: str) -> Type[Bottastic]:
+    """
+    Dynamically import a bot class from a string path like 'bottastic:PingPongBot'
+    """
+    try:
+        module_path, class_name = bot_path.split(":")
+        module = importlib.import_module(module_path)
+        bot_class = getattr(module, class_name)
+
+        if not issubclass(bot_class, Bottastic):
+            raise TypeError(f"{bot_path} is not a subclass of Bottastic")
+
+        return bot_class
+    except (ImportError, AttributeError, ValueError) as e:
+        raise ImportError(f"Could not import bot class {bot_path}: {e}")
+
+
+def create_interface(args):
+    """Create the appropriate Meshtastic interface based on command line args"""
+    if args.host:
+        return meshtastic.tcp_interface.TCPInterface(hostname=args.host)
+    elif args.port:
+        return meshtastic.serial_interface.SerialInterface(devPath=args.port)
+    else:
+        # Default: try to find a connected device automatically
+        return meshtastic.serial_interface.SerialInterface()
+
+
+def extract_bot_kwargs(args_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract kwargs for the bot from the parsed args"""
+    # Remove args used by the CLI itself
+    cli_args = ["host", "port", "bot_class", "verbose"]
+
+    # Convert remaining args to kwargs for the bot
+    return {k: v for k, v in args_dict.items() if k not in cli_args and v is not None}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Bottastic CLI for Meshtastic bots")
+
+    # Connection options
+    connection_group = parser.add_argument_group("Connection Options")
+    connection_group.add_argument(
+        "--host", type=str, help="Connect via TCP to a specified hostname/IP"
+    )
+    connection_group.add_argument(
+        "--port",
+        type=str,
+        help="Connect via serial to a specified port (e.g., /dev/ttyUSB0)",
+    )
+
+    # Bot options
+    parser.add_argument(
+        "bot_class", type=str, help="Bot class to run in format 'module:ClassName'"
+    )
+    parser.add_argument(
+        "--echo_sent", type=bool, default=False, help="Echo sent messages to console"
+    )
+    parser.add_argument(
+        "--echo_recieved",
+        type=bool,
+        default=False,
+        help="Echo received messages to console",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Enable verbose logging"
+    )
+
+    args = parser.parse_args()
+
+    # Set up logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=log_level)
+
+    # Import the specified bot class
+    try:
+        bot_class = import_bot_class(args.bot_class)
+    except ImportError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Create the appropriate interface
+    try:
+        interface = create_interface(args)
+    except Exception as e:
+        print(f"Error connecting to Meshtastic device: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Extract kwargs for the bot
+    kwargs = extract_bot_kwargs(vars(args))
+
+    # Create and run the bot
+    try:
+        bot = bot_class(interface, **kwargs)
+        bot.run()
+    except KeyboardInterrupt:
+        print("Bot stopped by user")
+    except Exception as e:
+        print(f"Error running bot: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        interface.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/bottastic/cli.py
+++ b/bottastic/cli.py
@@ -71,7 +71,7 @@ def main():
         "--echo_sent", type=bool, default=False, help="Echo sent messages to console"
     )
     parser.add_argument(
-        "--echo_recieved",
+        "--echo_received",
         type=bool,
         default=False,
         help="Echo received messages to console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,10 @@ requires-python = ">=3.12.5"
 dependencies = [
     "meshtastic>=2.6.0",
 ]
+
+[project.scripts]
+bottastic = "bottastic.cli:main"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
...and update project configuration to allow `uv run bottastic`

You can use this like so:

```bash
uv run bottastic --port /dev/ttyUSB0 bottastic.bottastic:PingPongBot
```

(or use `--host XXX` for `TcpInterface`)



```
bottastic (main) ✗ uv run bottastic --help
usage: bottastic [-h] [--host HOST] [--port PORT] [--echo_sent ECHO_SENT] [--echo_recieved ECHO_RECIEVED] [--verbose] bot_class

Bottastic CLI for Meshtastic bots

positional arguments:
  bot_class             Bot class to run in format 'module:ClassName'

options:
  -h, --help            show this help message and exit
  --echo_sent ECHO_SENT
                        Echo sent messages to console
  --echo_recieved ECHO_RECIEVED
                        Echo received messages to console
  --verbose, -v         Enable verbose logging

Connection Options:
  --host HOST           Connect via TCP to a specified hostname/IP
  --port PORT           Connect via serial to a specified port (e.g., /dev/ttyUSB0)
```